### PR TITLE
Code ownership for the mega project

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,0 +1,9 @@
+# Code ownership for the MEGA project
+
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @Gepardec/mega-dev will be requested for
+# review when someone opens a pull request.
+*       @Gepardec/mega-dev


### PR DESCRIPTION
The mega-dev team should be the code owners for the project.
If you want to be automatically included as default reviewer for pull requests: Join the team!

It is also possible to be only added as reviewer if certain types of files change or files in specific folders. (see: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax)