### PR TITLE
#151 Fixed bug that did not detect missing journey back

### DIFF
--- a/mega-zep-backend/src/main/java/com/gepardec/mega/domain/model/monthlyreport/JourneyDirection.java
+++ b/mega-zep-backend/src/main/java/com/gepardec/mega/domain/model/monthlyreport/JourneyDirection.java
@@ -11,7 +11,8 @@ import java.util.stream.Stream;
 public enum JourneyDirection {
     TO_AIM("0"),
     FURTHER("1"),
-    BACK("2");
+    BACK("2"),
+    INVALIDATE("invalidate");
 
     private String direction;
 

--- a/mega-zep-backend/src/main/java/com/gepardec/mega/service/impl/monthlyreport/JourneyDirectionHandler.java
+++ b/mega-zep-backend/src/main/java/com/gepardec/mega/service/impl/monthlyreport/JourneyDirectionHandler.java
@@ -17,15 +17,20 @@ public class JourneyDirectionHandler {
 
         if (journeyDirection == JourneyDirection.TO_AIM) {
             if (beforeJourneyDirection == JourneyDirection.TO_AIM || beforeJourneyDirection == JourneyDirection.FURTHER) {
-                resetHandler();
                 return Optional.of(Warning.WARNING_JOURNEY_BACK_MISSING);
             }
         } else if ((journeyDirection == JourneyDirection.FURTHER || journeyDirection == JourneyDirection.BACK)
                 && beforeJourneyDirection == JourneyDirection.BACK) {
-            resetHandler();
             return Optional.of(Warning.WARNING_JOURNEY_TO_AIM_MISSING);
+        } else if (journeyDirection == JourneyDirection.INVALIDATE) {
+            resetHandler();
+            return Optional.of(Warning.WARNING_JOURNEY_BACK_MISSING);
         }
         beforeJourneyDirection = journeyDirection;
         return Optional.empty();
+    }
+
+    public boolean isJourneyFinished() {
+        return beforeJourneyDirection == JourneyDirection.BACK;
     }
 }

--- a/mega-zep-backend/src/main/java/com/gepardec/mega/service/impl/monthlyreport/WarningCalculator.java
+++ b/mega-zep-backend/src/main/java/com/gepardec/mega/service/impl/monthlyreport/WarningCalculator.java
@@ -134,14 +134,23 @@ public class WarningCalculator {
     }
 
 
-    List<JourneyWarning> determineJourneyWarnings(List<ProjectTimeEntry> projectTimeEntryList) {
+    public List<JourneyWarning> determineJourneyWarnings(List<ProjectTimeEntry> projectTimeEntryList) {
         JourneyDirectionHandler journeyDirectionHandler = new JourneyDirectionHandler();
-        for (ProjectTimeEntry projectTimeEntry : projectTimeEntryList) {
+        Optional<JourneyEntry> lastJourneyEntry = Optional.empty();
+
+        for (int i = 0; i < projectTimeEntryList.size(); i++) {
+            ProjectTimeEntry projectTimeEntry = projectTimeEntryList.get(i);
 
             if (projectTimeEntry instanceof JourneyEntry) {
                 JourneyEntry journeyEntry = (JourneyEntry) projectTimeEntry;
                 journeyDirectionHandler.moveTo(journeyEntry.getJourneyDirection())
                         .ifPresent(warning -> addToJourneyWarnings(journeyEntry, warning));
+                lastJourneyEntry = Optional.of(journeyEntry);
+            }
+
+            if (i == projectTimeEntryList.size() - 1 && !journeyDirectionHandler.isJourneyFinished()) {
+                lastJourneyEntry.ifPresent(journeyEntry -> journeyDirectionHandler.moveTo(JourneyDirection.INVALIDATE)
+                        .ifPresent(warning -> addToJourneyWarnings(journeyEntry, warning)));
             }
         }
         return journeyWarnings;

--- a/mega-zep-backend/src/test/java/com/gepardec/mega/monthlyreport/journey/JourneyDirectionHandlerTest.java
+++ b/mega-zep-backend/src/test/java/com/gepardec/mega/monthlyreport/journey/JourneyDirectionHandlerTest.java
@@ -26,15 +26,15 @@ public class JourneyDirectionHandlerTest {
     }
 
     @Test
-    void moveTo_further_warningNoReturn() {
+    void moveTo_Further_shouldReturnToAimMissingError() {
         journeyDirectionHandler = new JourneyDirectionHandler();
         assertToAimMissing(journeyDirectionHandler.moveTo(FURTHER));
     }
 
     @Test
-    void moveTo_Further_shouldReturnToAimMissingError() {
+    void moveTo_Back_shouldReturnToAimMissingError() {
         journeyDirectionHandler = new JourneyDirectionHandler();
-        assertToAimMissing(journeyDirectionHandler.moveTo(FURTHER));
+        assertToAimMissing(journeyDirectionHandler.moveTo(BACK));
     }
 
     @Test

--- a/mega-zep-backend/src/test/java/com/gepardec/mega/monthlyreport/warning/WarningCalculatorTest.java
+++ b/mega-zep-backend/src/test/java/com/gepardec/mega/monthlyreport/warning/WarningCalculatorTest.java
@@ -2,9 +2,12 @@ package com.gepardec.mega.monthlyreport.warning;
 
 import com.gepardec.mega.domain.model.monthlyreport.*;
 import com.gepardec.mega.service.impl.monthlyreport.WarningCalculator;
+import com.gepardec.mega.service.impl.monthlyreport.WarningConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
@@ -21,6 +24,8 @@ public class WarningCalculatorTest {
     @InjectMocks
     private WarningCalculator warningCalculator;
 
+    @Mock
+    private WarningConfig warningConfig;
 
     @Test
     void determineTimeWarnings_oneEntryMoreThan6Hours_warning() {
@@ -81,6 +86,76 @@ public class WarningCalculatorTest {
                 () -> assertNull(warnings.get(1).getExcessWorkTime()));
     }
 
+    @Test
+    void determineJourneyWarnings_journeyToAimMissing_Warning() {
+        ArrayList<ProjectTimeEntry> projectTimes = new ArrayList<>();
+        projectTimes.add(
+                new ProjectTimeEntry(LocalDateTime.of(2020, 01, 07, 14, 00),
+                        LocalDateTime.of(2020, 01, 07, 16, 00),
+                        Task.BEARBEITEN));
+        projectTimes.add(
+                new JourneyEntry(LocalDateTime.of(2020, 01, 07, 14, 00),
+                        LocalDateTime.of(2020, 01, 07, 16, 00),
+                        Task.REISEN,
+                        JourneyDirection.BACK));
+
+        List<JourneyWarning> warnings = warningCalculator.determineJourneyWarnings(projectTimes);
+        assertAll(() -> assertEquals(1, warnings.size()),
+                () -> assertEquals(LocalDate.of(2020, 01, 07), warnings.get(0).getDate()),
+                () -> assertEquals(1, warnings.get(0).getWarnings().size()));
+        System.out.println(warnings.get(0).getWarnings().get(0));
+    }
+
+    @Test
+    void determineJourneyWarnings_journeyBackMissing_Warning() {
+        ArrayList<ProjectTimeEntry> projectTimes = new ArrayList<>();
+        projectTimes.add(
+                new JourneyEntry(LocalDateTime.of(2020, 01, 07, 10, 00),
+                        LocalDateTime.of(2020, 01, 07, 11, 00),
+                        Task.REISEN,
+                        JourneyDirection.TO_AIM));
+        projectTimes.add(
+                new ProjectTimeEntry(LocalDateTime.of(2020, 01, 07, 11, 00),
+                        LocalDateTime.of(2020, 01, 07, 16, 00),
+                        Task.BEARBEITEN));
+
+        List<JourneyWarning> warnings = warningCalculator.determineJourneyWarnings(projectTimes);
+        assertAll(() -> assertEquals(1, warnings.size()),
+                () -> assertEquals(LocalDate.of(2020, 01, 07), warnings.get(0).getDate()),
+                () -> assertEquals(1, warnings.get(0).getWarnings().size()));
+    }
+
+    @Test
+    void determineJourneyWarnings_TwoJourneyToAimMissingAndTwoJourneyBackMissing_Warning() {
+        List<ProjectTimeEntry> projectTimes = createEntriesWithAllKindOfJourneyWarnings();
+
+        String missingJourneyBack = "Warnung: Rückreise fehlt oder ist nach dem Zeitraum";
+        Mockito.when(warningConfig.getMissingJourneyBack()).thenReturn(missingJourneyBack);
+
+        String missingJourneyToAim = "Warnung: Hinreise fehlt oder ist vor dem Zeitraum";
+        Mockito.when(warningConfig.getMissingJourneyToAim()).thenReturn(missingJourneyToAim);
+
+        List<JourneyWarning> warnings = warningCalculator.determineJourneyWarnings(projectTimes);
+        assertAll(
+                () -> assertEquals(4, warnings.size()),
+                () -> assertEquals(LocalDate.of(2020, 7, 21), warnings.get(0).getDate()),
+                () -> assertEquals(1, warnings.get(0).getWarnings().size()),
+                () -> assertEquals(missingJourneyToAim, warnings.get(0).getWarnings().get(0)),
+
+                () -> assertEquals(LocalDate.of(2020, 7, 24), warnings.get(1).getDate()),
+                () -> assertEquals(1, warnings.get(1).getWarnings().size()),
+                () -> assertEquals(missingJourneyBack, warnings.get(1).getWarnings().get(0)),
+
+                () -> assertEquals(LocalDate.of(2020, 7, 28), warnings.get(2).getDate()),
+                () -> assertEquals(1, warnings.get(2).getWarnings().size()),
+                () -> assertEquals(missingJourneyToAim, warnings.get(2).getWarnings().get(0)),
+
+                () -> assertEquals(LocalDate.of(2020, 7, 29), warnings.get(3).getDate()),
+                () -> assertEquals(1, warnings.get(3).getWarnings().size()),
+                () -> assertEquals(missingJourneyBack, warnings.get(3).getWarnings().get(0))
+        );
+    }
+
     private static List<ProjectTimeEntry> createEntriesMoreThan6Hours() {
         return Arrays.asList(
                 new ProjectTimeEntry(LocalDateTime.of(2020, 01, 07, 9, 00),
@@ -130,6 +205,81 @@ public class WarningCalculatorTest {
         projectTimes.add(
                 new ProjectTimeEntry(LocalDateTime.of(2020, 1, 8, 6, 00),
                         LocalDateTime.of(2020, 1, 8, 8, 00),
+                        Task.BEARBEITEN));
+        return projectTimes;
+    }
+
+    private static List<ProjectTimeEntry> createEntriesWithAllKindOfJourneyWarnings() {
+        List<ProjectTimeEntry> projectTimes = new ArrayList<>();
+
+        // Day 1 (TO_AIM missing)
+        projectTimes.add(
+                new ProjectTimeEntry(LocalDateTime.of(2020, 7, 21, 9, 0),
+                        LocalDateTime.of(2020, 7, 21, 15, 0),
+                        Task.BEARBEITEN));
+        projectTimes.add(
+                new JourneyEntry(LocalDateTime.of(2020, 7, 21, 15, 0),
+                        LocalDateTime.of(2020, 7, 21, 16, 0),
+                        Task.REISEN,
+                        JourneyDirection.BACK));
+
+        // Day 2 (valid)
+        projectTimes.add(
+                new JourneyEntry(LocalDateTime.of(2020, 7, 22, 8, 0),
+                        LocalDateTime.of(2020, 7, 22, 9, 0),
+                        Task.REISEN,
+                        JourneyDirection.TO_AIM));
+        projectTimes.add(
+                new ProjectTimeEntry(LocalDateTime.of(2020, 7, 22, 9, 0),
+                        LocalDateTime.of(2020, 7, 22, 15, 0),
+                        Task.BEARBEITEN));
+        projectTimes.add(
+                new JourneyEntry(LocalDateTime.of(2020, 7, 22, 15, 0),
+                        LocalDateTime.of(2020, 7, 22, 16, 0),
+                        Task.REISEN,
+                        JourneyDirection.BACK));
+
+        // Day 3 (BACK missing)
+        projectTimes.add(
+                new JourneyEntry(LocalDateTime.of(2020, 7, 23, 8, 0),
+                        LocalDateTime.of(2020, 7, 23, 9, 0),
+                        Task.REISEN,
+                        JourneyDirection.TO_AIM));
+        projectTimes.add(
+                new ProjectTimeEntry(LocalDateTime.of(2020, 7, 23, 9, 0),
+                        LocalDateTime.of(2020, 7, 23, 15, 0),
+                        Task.BEARBEITEN));
+
+        // Day 4 (valid)
+        projectTimes.add(
+                new JourneyEntry(LocalDateTime.of(2020, 7, 24, 15, 0),
+                        LocalDateTime.of(2020, 7, 24, 16, 0),
+                        Task.REISEN,
+                        JourneyDirection.TO_AIM));
+        projectTimes.add(
+                new JourneyEntry(LocalDateTime.of(2020, 7, 24, 16, 0),
+                        LocalDateTime.of(2020, 7, 24, 17, 0),
+                        Task.REISEN,
+                        JourneyDirection.BACK));
+
+        // Day 5 (TO_AIM missing)
+        projectTimes.add(
+                new JourneyEntry(LocalDateTime.of(2020, 7, 28, 15, 0),
+                        LocalDateTime.of(2020, 7, 28, 16, 0),
+                        Task.REISEN,
+                        JourneyDirection.BACK));
+
+        // Day 6 (BACK missing)
+        projectTimes.add(
+                new JourneyEntry(LocalDateTime.of(2020, 7, 29, 15, 0),
+                        LocalDateTime.of(2020, 7, 29, 16, 0),
+                        Task.REISEN,
+                        JourneyDirection.TO_AIM));
+
+        // Day 7 (Dummy)
+        projectTimes.add(
+                new ProjectTimeEntry(LocalDateTime.of(2020, 7, 30, 15, 0),
+                        LocalDateTime.of(2020, 7, 30, 16, 0),
                         Task.BEARBEITEN));
         return projectTimes;
     }


### PR DESCRIPTION
When the entry for a return journey is missing and no more journeys are booked after that in the current billing month, the algorithm did not detect the missing entry.
A journey gets invalidated now if the last project entry of this month did not end the journey.
One redundant test method in JourneyDirectionHandlerTest.java was removed and one more added.
Also test cases were implemented for the improved algorithm.