### PR TITLE
#173 changed month end report

### DIFF
--- a/mega-zep-backend/src/main/java/com/gepardec/mega/rest/WorkerResource.java
+++ b/mega-zep-backend/src/main/java/com/gepardec/mega/rest/WorkerResource.java
@@ -28,11 +28,7 @@ public class WorkerResource {
     @Path("/monthendreports")
     @Produces(MediaType.APPLICATION_JSON)
     public Response getMonthEndReports() {
-        final MonthlyReport monthlyReport = monthlyReportService.getMonthendReportForUser(userContext.getUser().userId());
-
-        if (monthlyReport == null) {
-            return Response.status(Response.Status.NOT_FOUND).build();
-        }
+        MonthlyReport monthlyReport = monthlyReportService.getMonthendReportForUser(userContext.getUser().userId());
         return Response.ok(monthlyReport).build();
     }
 }

--- a/mega-zep-backend/src/main/java/com/gepardec/mega/rest/WorkerResource.java
+++ b/mega-zep-backend/src/main/java/com/gepardec/mega/rest/WorkerResource.java
@@ -2,7 +2,9 @@ package com.gepardec.mega.rest;
 
 import com.gepardec.mega.application.security.Secured;
 import com.gepardec.mega.application.security.UserContext;
+import com.gepardec.mega.domain.model.Employee;
 import com.gepardec.mega.domain.model.monthlyreport.MonthlyReport;
+import com.gepardec.mega.service.api.employee.EmployeeService;
 import com.gepardec.mega.service.api.monthlyreport.MonthlyReportService;
 
 import javax.enterprise.context.RequestScoped;
@@ -12,6 +14,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.Collections;
 
 @RequestScoped
 @Secured
@@ -24,11 +27,23 @@ public class WorkerResource {
     @Inject
     UserContext userContext;
 
+    @Inject
+    EmployeeService employeeService;
+
     @GET
     @Path("/monthendreports")
     @Produces(MediaType.APPLICATION_JSON)
     public Response getMonthEndReports() {
-        MonthlyReport monthlyReport = monthlyReportService.getMonthendReportForUser(userContext.getUser().userId());
+        Employee employee = employeeService.getEmployee(userContext.getUser().userId());
+        MonthlyReport monthlyReport = monthlyReportService.getMonthendReportForUser(employee.userId());
+
+        if (monthlyReport == null) {
+            monthlyReport = new MonthlyReport();
+            monthlyReport.setEmployee(employee);
+            monthlyReport.setJourneyWarnings(Collections.emptyList());
+            monthlyReport.setTimeWarnings(Collections.emptyList());
+        }
+
         return Response.ok(monthlyReport).build();
     }
 }

--- a/mega-zep-backend/src/main/java/com/gepardec/mega/service/impl/monthlyreport/MonthlyReportServiceImpl.java
+++ b/mega-zep-backend/src/main/java/com/gepardec/mega/service/impl/monthlyreport/MonthlyReportServiceImpl.java
@@ -10,7 +10,6 @@ import com.gepardec.mega.zep.ZepService;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
-import java.util.Collections;
 import java.util.List;
 
 @RequestScoped
@@ -24,28 +23,20 @@ public class MonthlyReportServiceImpl implements MonthlyReportService {
 
     @Override
     public MonthlyReport getMonthendReportForUser(final String userId) {
-
         Employee employee = zepService.getEmployee(userId);
-
         return calcWarnings(zepService.getProjectTimes(employee), employee);
     }
 
     private MonthlyReport calcWarnings(List<ProjectTimeEntry> projectTimeList, Employee employee) {
-        MonthlyReport monthlyReport = new MonthlyReport();
-
         if (projectTimeList == null || projectTimeList.isEmpty()) {
-            monthlyReport = new MonthlyReport();
-            monthlyReport.setEmployee(employee);
-            monthlyReport.setJourneyWarnings(Collections.emptyList());
-            monthlyReport.setTimeWarnings(Collections.emptyList());
-
-            return monthlyReport;
+            return null;
         }
 
         final WarningCalculator warningCalculator = new WarningCalculator(warningConfig);
         final List<JourneyWarning> journeyWarnings = warningCalculator.determineJourneyWarnings(projectTimeList);
         final List<TimeWarning> timeWarnings = warningCalculator.determineTimeWarnings(projectTimeList);
 
+        MonthlyReport monthlyReport = new MonthlyReport();
         monthlyReport.setJourneyWarnings(journeyWarnings);
         monthlyReport.setTimeWarnings(timeWarnings);
         monthlyReport.setEmployee(employee);

--- a/mega-zep-backend/src/main/java/com/gepardec/mega/service/impl/monthlyreport/MonthlyReportServiceImpl.java
+++ b/mega-zep-backend/src/main/java/com/gepardec/mega/service/impl/monthlyreport/MonthlyReportServiceImpl.java
@@ -10,6 +10,7 @@ import com.gepardec.mega.zep.ZepService;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
+import java.util.Collections;
 import java.util.List;
 
 @RequestScoped
@@ -30,17 +31,25 @@ public class MonthlyReportServiceImpl implements MonthlyReportService {
     }
 
     private MonthlyReport calcWarnings(List<ProjectTimeEntry> projectTimeList, Employee employee) {
+        MonthlyReport monthlyReport = new MonthlyReport();
+
         if (projectTimeList == null || projectTimeList.isEmpty()) {
-            return null;
+            monthlyReport = new MonthlyReport();
+            monthlyReport.setEmployee(employee);
+            monthlyReport.setJourneyWarnings(Collections.emptyList());
+            monthlyReport.setTimeWarnings(Collections.emptyList());
+
+            return monthlyReport;
         }
+
         final WarningCalculator warningCalculator = new WarningCalculator(warningConfig);
         final List<JourneyWarning> journeyWarnings = warningCalculator.determineJourneyWarnings(projectTimeList);
         final List<TimeWarning> timeWarnings = warningCalculator.determineTimeWarnings(projectTimeList);
 
-        final MonthlyReport monthlyReport = new MonthlyReport();
         monthlyReport.setJourneyWarnings(journeyWarnings);
         monthlyReport.setTimeWarnings(timeWarnings);
         monthlyReport.setEmployee(employee);
+
         return monthlyReport;
     }
 }


### PR DESCRIPTION
The REST method WorkerResource.getMonthEndReports does not return 404 any more, but empty data when no project times were found.
This empty data is set in MonthlyReportServiceImpl.calcWarnings. The reason for this is that the interceptor in the frontend catches all 404 errors, but configuring exceptions for only the monthly report is unnecessarily complex. Also returning empty data instead of 404 is not a violation against the REST standard.