### PR TITLE
Bugfix of unloadable resource '/monthlyReport'

### DIFF
--- a/mega-zep-backend/src/main/java/com/gepardec/mega/domain/model/monthlyreport/Task.java
+++ b/mega-zep-backend/src/main/java/com/gepardec/mega/domain/model/monthlyreport/Task.java
@@ -25,7 +25,7 @@ public enum Task {
     }
 
     public static Optional<Task> fromString(String name) {
-        return Optional.ofNullable(tasks.get(name));
+        return Optional.ofNullable(tasks.get(name.toUpperCase()));
     }
 
 }

--- a/mega-zep-backend/src/main/java/com/gepardec/mega/zep/ZepServiceImpl.java
+++ b/mega-zep-backend/src/main/java/com/gepardec/mega/zep/ZepServiceImpl.java
@@ -27,16 +27,19 @@ public class ZepServiceImpl implements ZepService {
     private final Logger logger;
     private final ZepSoapPortType zepSoapPortType;
     private final ZepSoapProvider zepSoapProvider;
+    private final ProjectTimeMapper projectTimeMapper;
 
     @Inject
     public ZepServiceImpl(final EmployeeMapper employeeMapper,
             final Logger logger,
             final ZepSoapPortType zepSoapPortType,
-            final ZepSoapProvider zepSoapProvider) {
+            final ZepSoapProvider zepSoapProvider,
+            final ProjectTimeMapper projectTimeMapper) {
         this.employeeMapper = employeeMapper;
         this.logger = logger;
         this.zepSoapPortType = zepSoapPortType;
         this.zepSoapProvider = zepSoapProvider;
+        this.projectTimeMapper = projectTimeMapper;
     }
 
     @Override
@@ -93,7 +96,7 @@ public class ZepServiceImpl implements ZepService {
 
         ReadProjektzeitenResponseType projectTimeResponse = zepSoapPortType.readProjektzeiten(projektzeitenRequest);
 
-        return ProjectTimeMapper.mapToEntryList(projectTimeResponse.getProjektzeitListe().getProjektzeiten());
+        return projectTimeMapper.mapToEntryList(projectTimeResponse.getProjektzeitListe().getProjektzeiten());
     }
 
     private ReadProjektzeitenSearchCriteriaType createProjectTimeSearchCriteria(Employee employee) {

--- a/mega-zep-backend/src/main/java/com/gepardec/mega/zep/mapper/ProjectTimeMapper.java
+++ b/mega-zep-backend/src/main/java/com/gepardec/mega/zep/mapper/ProjectTimeMapper.java
@@ -3,6 +3,7 @@ package com.gepardec.mega.zep.mapper;
 import com.gepardec.mega.domain.model.monthlyreport.*;
 import de.provantis.zep.ProjektzeitType;
 
+import javax.enterprise.context.ApplicationScoped;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
@@ -10,16 +11,17 @@ import java.util.stream.Collectors;
 
 import static com.gepardec.mega.domain.utils.DateUtils.parseDateTime;
 
+@ApplicationScoped
 public class ProjectTimeMapper {
 
-    public static List<ProjectEntry> mapToEntryList(List<ProjektzeitType> projectTimes) {
+    public List<ProjectEntry> mapToEntryList(List<ProjektzeitType> projectTimes) {
         return projectTimes.stream()
-                .map(ProjectTimeMapper::mapSingleTypeToEntry)
+                .map(this::mapSingleTypeToEntry)
                 .sorted(Comparator.comparing(ProjectEntry::getFromTime))
                 .collect(Collectors.toList());
     }
 
-    private static ProjectEntry mapSingleTypeToEntry(ProjektzeitType projektzeitType) {
+    private ProjectEntry mapSingleTypeToEntry(ProjektzeitType projektzeitType) {
         LocalDateTime fromTime = parseDateTime(projektzeitType.getDatum(), projektzeitType.getVon());
         LocalDateTime toTime = parseDateTime(projektzeitType.getDatum(), projektzeitType.getBis());
 

--- a/mega-zep-backend/src/test/java/com/gepardec/mega/zep/ZepServiceImplTest.java
+++ b/mega-zep-backend/src/test/java/com/gepardec/mega/zep/ZepServiceImplTest.java
@@ -6,6 +6,7 @@ import com.gepardec.mega.service.impl.employee.EmployeeMapper;
 import com.gepardec.mega.zep.ZepServiceException;
 import com.gepardec.mega.zep.ZepServiceImpl;
 import com.gepardec.mega.zep.ZepSoapProvider;
+import com.gepardec.mega.zep.mapper.ProjectTimeMapper;
 import de.provantis.zep.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,9 +33,11 @@ public class ZepServiceImplTest {
 
     private ZepServiceImpl beanUnderTest;
 
+    private ProjectTimeMapper projectTimeMapper = new ProjectTimeMapper();
+
     @BeforeEach
     void setUp() {
-        beanUnderTest = new ZepServiceImpl(new EmployeeMapper(), logger, zepSoapPortType, zepSoapProvider);
+        beanUnderTest = new ZepServiceImpl(new EmployeeMapper(), logger, zepSoapPortType, zepSoapProvider, projectTimeMapper);
     }
 
     @Test

--- a/mega-zep-backend/src/test/java/com/gepardec/mega/zep/mapper/ProjectTimeMapperTest.java
+++ b/mega-zep-backend/src/test/java/com/gepardec/mega/zep/mapper/ProjectTimeMapperTest.java
@@ -4,51 +4,95 @@ import com.gepardec.mega.domain.model.monthlyreport.JourneyTimeEntry;
 import com.gepardec.mega.domain.model.monthlyreport.ProjectEntry;
 import com.gepardec.mega.domain.model.monthlyreport.ProjectTimeEntry;
 import de.provantis.zep.ProjektzeitType;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class ProjectTimeMapperTest {
 
-    @Test
-    void mapSingleTypeToEntry_taetigkeitNotEnumType_ThrowsException() {
-        ProjektzeitType projektzeitType = createDefaultProjektzeitType();
-        projektzeitType.setTaetigkeit("testen");
+    private ProjectTimeMapper mapper;
 
-        assertThrows(IllegalArgumentException.class, () -> ProjectTimeMapper.mapToEntryList(List.of(projektzeitType)));
+    @BeforeEach
+    void beforeEach() {
+        mapper = new ProjectTimeMapper();
     }
 
     @Test
-    void mapSingleTypeToEntry_taetigkeitEqualsReiseAndReiseRichtungNotEnumType_ThrowsException() {
+    void mapSingleTypeToEntry_twhenTaetigkeitNotEnumType_thenThrowsException() {
+        ProjektzeitType projektzeitType = createDefaultProjektzeitType();
+        projektzeitType.setTaetigkeit("testen");
+
+        assertThrows(IllegalArgumentException.class, () -> mapper.mapToEntryList(List.of(projektzeitType)));
+    }
+
+    @Test
+    void mapSingleTypeToEntry_whenTaetigkeitEqualsReiseAndReiseRichtungNotEnumType_thenThrowsException() {
         ProjektzeitType projektzeitType = createDefaultProjektzeitType();
         projektzeitType.setTaetigkeit("reisen");
         projektzeitType.setReiseRichtung("100");
 
-        assertThrows(IllegalArgumentException.class, () -> ProjectTimeMapper.mapToEntryList(List.of(projektzeitType)));
+        assertThrows(IllegalArgumentException.class, () -> mapper.mapToEntryList(List.of(projektzeitType)));
     }
 
     @Test
-    void mapSingleTypeToEntry_taetigkeitEqualsReiseAndReiseRichtungEqualsTo_ReturnsProjectTimeEntry() {
+    void mapSingleTypeToEntry_whenTaetigkeitEqualsReiseAndReiseRichtungIsTO_thenReturnsProjectTimeEntryInstance() {
         ProjektzeitType projektzeitType = createDefaultProjektzeitType();
 
-        List<ProjectEntry> result = ProjectTimeMapper.mapToEntryList(List.of(projektzeitType));
+        List<ProjectEntry> result = mapper.mapToEntryList(List.of(projektzeitType));
 
         assertEquals(1, result.size());
         assertTrue(result.get(0) instanceof ProjectTimeEntry);
     }
 
     @Test
-    void mapSingleTypeToEntry_taetigkeitEqualsReiseAndReiseRichtungEqualsTo_ReturnsJourneyTimeEntry() {
+    void mapSingleTypeToEntry_whenTaetigkeitEqualsReiseAndReiseRichtungIsTO_thenReturnsMappedProjectTimeEntry() {
+        ProjektzeitType projektzeitType = createDefaultProjektzeitType();
+        final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        final DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("hh:mm");
+
+        List<ProjectEntry> result = mapper.mapToEntryList(List.of(projektzeitType));
+
+        assertEquals(1, result.size());
+        final ProjectTimeEntry projectTimeEntry = (ProjectTimeEntry) result.get(0);
+        assertEquals(projektzeitType.getDatum(), projectTimeEntry.getDate().format(dateFormatter));
+        assertEquals(projektzeitType.getVon(), projectTimeEntry.getFromTime().format(timeFormatter));
+        assertEquals(projektzeitType.getBis(), projectTimeEntry.getToTime().format(timeFormatter));
+        assertEquals(projektzeitType.getTaetigkeit().toUpperCase(), projectTimeEntry.getTask().name());
+    }
+
+    @Test
+    void mapSingleTypeToEntry_whenTaetigkeitEqualsReiseAndReiseRichtungIsTo_thenReturnsJourneyTimeEntryInstance() {
         ProjektzeitType projektzeitType = createDefaultProjektzeitType();
         projektzeitType.setTaetigkeit("reisen");
         projektzeitType.setReiseRichtung("0");  // JourneyDirection.TO
 
-        List<ProjectEntry> result = ProjectTimeMapper.mapToEntryList(List.of(projektzeitType));
+        List<ProjectEntry> result = mapper.mapToEntryList(List.of(projektzeitType));
 
         assertEquals(1, result.size());
         assertTrue(result.get(0) instanceof JourneyTimeEntry);
+    }
+
+    @Test
+    void mapSingleTypeToEntry_whenTaetigkeitIsReiseAndReiseRichtungIsTO_thenReturnsMappedJourneyTimeEntry() {
+        ProjektzeitType projektzeitType = createDefaultProjektzeitType();
+        projektzeitType.setTaetigkeit("reisen");
+        projektzeitType.setReiseRichtung("0");  // JourneyDirection.TO
+        final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        final DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("hh:mm");
+
+        List<ProjectEntry> result = mapper.mapToEntryList(List.of(projektzeitType));
+
+        assertEquals(1, result.size());
+        final JourneyTimeEntry journeyTimeEntry = (JourneyTimeEntry) result.get(0);
+        assertEquals(projektzeitType.getReiseRichtung(), journeyTimeEntry.getJourneyDirection().getDirection());
+        assertEquals(projektzeitType.getDatum(), journeyTimeEntry.getDate().format(dateFormatter));
+        assertEquals(projektzeitType.getVon(), journeyTimeEntry.getFromTime().format(timeFormatter));
+        assertEquals(projektzeitType.getBis(), journeyTimeEntry.getToTime().format(timeFormatter));
+        assertEquals(projektzeitType.getTaetigkeit().toUpperCase(), journeyTimeEntry.getTask().name());
     }
 
     private static ProjektzeitType createDefaultProjektzeitType() {

--- a/mega-zep-backend/src/test/java/com/gepardec/mega/zep/mapper/ProjectTimeMapperTest.java
+++ b/mega-zep-backend/src/test/java/com/gepardec/mega/zep/mapper/ProjectTimeMapperTest.java
@@ -1,0 +1,62 @@
+package com.gepardec.mega.zep.mapper;
+
+import com.gepardec.mega.domain.model.monthlyreport.JourneyTimeEntry;
+import com.gepardec.mega.domain.model.monthlyreport.ProjectEntry;
+import com.gepardec.mega.domain.model.monthlyreport.ProjectTimeEntry;
+import de.provantis.zep.ProjektzeitType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProjectTimeMapperTest {
+
+    @Test
+    void mapSingleTypeToEntry_taetigkeitNotEnumType_ThrowsException() {
+        ProjektzeitType projektzeitType = createDefaultProjektzeitType();
+        projektzeitType.setTaetigkeit("testen");
+
+        assertThrows(IllegalArgumentException.class, () -> ProjectTimeMapper.mapToEntryList(List.of(projektzeitType)));
+    }
+
+    @Test
+    void mapSingleTypeToEntry_taetigkeitEqualsReiseAndReiseRichtungNotEnumType_ThrowsException() {
+        ProjektzeitType projektzeitType = createDefaultProjektzeitType();
+        projektzeitType.setTaetigkeit("reisen");
+        projektzeitType.setReiseRichtung("100");
+
+        assertThrows(IllegalArgumentException.class, () -> ProjectTimeMapper.mapToEntryList(List.of(projektzeitType)));
+    }
+
+    @Test
+    void mapSingleTypeToEntry_taetigkeitEqualsReiseAndReiseRichtungEqualsTo_ReturnsProjectTimeEntry() {
+        ProjektzeitType projektzeitType = createDefaultProjektzeitType();
+
+        List<ProjectEntry> result = ProjectTimeMapper.mapToEntryList(List.of(projektzeitType));
+
+        assertEquals(1, result.size());
+        assertTrue(result.get(0) instanceof ProjectTimeEntry);
+    }
+
+    @Test
+    void mapSingleTypeToEntry_taetigkeitEqualsReiseAndReiseRichtungEqualsTo_ReturnsJourneyTimeEntry() {
+        ProjektzeitType projektzeitType = createDefaultProjektzeitType();
+        projektzeitType.setTaetigkeit("reisen");
+        projektzeitType.setReiseRichtung("0");  // JourneyDirection.TO
+
+        List<ProjectEntry> result = ProjectTimeMapper.mapToEntryList(List.of(projektzeitType));
+
+        assertEquals(1, result.size());
+        assertTrue(result.get(0) instanceof JourneyTimeEntry);
+    }
+
+    private static ProjektzeitType createDefaultProjektzeitType() {
+        ProjektzeitType projektzeitType = new ProjektzeitType();
+        projektzeitType.setDatum("2020-07-01");
+        projektzeitType.setVon("08:00");
+        projektzeitType.setBis("10:00");
+        projektzeitType.setTaetigkeit("bearbeiten");
+        return projektzeitType;
+    }
+}

--- a/mega-zep-frontend/src/main/angular/frontend/src/app/modules/monthly-report/display-monthly-report/display-monthly-report.component.html
+++ b/mega-zep-frontend/src/main/angular/frontend/src/app/modules/monthly-report/display-monthly-report/display-monthly-report.component.html
@@ -48,7 +48,7 @@
         <ng-container matColumnDef="no-warnings">
           <mat-header-cell *matHeaderCellDef>
             <mat-checkbox [checked]="true" [disabled]="true"></mat-checkbox>
-            <a class="no-warning-text">Alle Eingaben sind korrekt</a>
+            <span class="no-warning-text">Alle Eingaben sind korrekt</span>
           </mat-header-cell>
         </ng-container>
 
@@ -91,7 +91,7 @@
         <ng-container matColumnDef="no-warnings">
           <mat-header-cell *matHeaderCellDef>
             <mat-checkbox [checked]="true" [disabled]="true"></mat-checkbox>
-            <a class="no-warning-text">Alle Eingaben sind korrekt</a>
+            <span class="no-warning-text">Alle Eingaben sind korrekt</span>
           </mat-header-cell>
         </ng-container>
 

--- a/mega-zep-frontend/src/main/angular/frontend/src/app/modules/shared/components/login/login.component.html
+++ b/mega-zep-frontend/src/main/angular/frontend/src/app/modules/shared/components/login/login.component.html
@@ -2,7 +2,7 @@
   <mat-card class="mat-elevation-z8 d-flex text-center justify-content-center align-items-center">
     <mat-card-content>
       <img alt="Google G" class="google-img" src="../../../../../assets/google-g.png">
-      <a class="text">Über Google anmelden</a>
+      <span class="text">Über Google anmelden</span>
       <button (click)="login()" class="w-75" color="primary" mat-raised-button>Anmelden</button>
     </mat-card-content>
   </mat-card>


### PR DESCRIPTION
- when mapping the ZEP-type ProjektzeitType to internal ProjectEntry, the task could not be converted to enum type Task
- implemented tests for class ProjectTimeMapper