### PR TITLE
- locking ocp builds

### DIFF
--- a/jenkins/src/build/Jenkinsfile
+++ b/jenkins/src/build/Jenkinsfile
@@ -52,12 +52,14 @@ pipeline {
                                 script {
                                     container('nodejs') {
                                         dir('mega-zep-frontend/src/main/angular/frontend') {
-                                            openshift.withCluster() {
-                                                sh "oc start-build mega-zep-frontend --commit=${env.GIT_COMMIT} \
+                                            lock('mega-build-openshift-nodejs') {
+                                                openshift.withCluster() {
+                                                    sh "oc start-build mega-zep-frontend --commit=${env.GIT_COMMIT} \
                                                                                          --from-dir=dist/frontend \
                                                                                          --follow \
                                                                                          --wait"
-                                                openshift.tag("mega-zep-frontend:latest", "mega-zep-frontend:${env.REVISION}")
+                                                    openshift.tag("mega-zep-frontend:latest", "mega-zep-frontend:${env.REVISION}")
+                                                }
                                             }
                                         }
                                     }
@@ -114,12 +116,13 @@ pipeline {
                                 script {
                                     container('quarkus') {
                                         dir('mega-zep-backend/target/') {
-                                            openshift.withCluster() {
-                                                def artifact = "mega-zep-backend-${env.REVISION}-runner.jar"
-                                                sh "oc start-build mega-zep-backend --from-file=${artifact} --follow --wait"
-                                                openshift.tag("mega-zep-backend:latest", "mega-zep-backend:${env.REVISION}")
+                                            lock('mega-build-openshift-quarkus') {
+                                                openshift.withCluster() {
+                                                    def artifact = "mega-zep-backend-${env.REVISION}-runner.jar"
+                                                    sh "oc start-build mega-zep-backend --from-file=${artifact} --follow --wait"
+                                                    openshift.tag("mega-zep-backend:latest", "mega-zep-backend:${env.REVISION}")
+                                                }
                                             }
-                                            copyImage("mega-zep-backend:${env.REVISION}")
                                         }
                                     }
                                 }


### PR DESCRIPTION
 Sometimes, especially when builds are executed in parallel, then we face the issue that the ocp image builds fail.
Therefore I have added a lock block around the ocp image build, so that other build executions don't interfere with each other